### PR TITLE
Optimize production build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 /node_modules
 yarn.lock
+.gitignore
+.env.dist
+.flowconfig
+README.md

--- a/Dockerfile_Prod
+++ b/Dockerfile_Prod
@@ -1,0 +1,18 @@
+# Use a lighter version of Node as a parent image
+FROM mhart/alpine-node:11
+# Set the working directory to /api
+WORKDIR /api
+# copy package.json into the container at /api
+COPY package*.json /api/
+# install dependencies
+RUN yarn --prod
+# Copy the current productin build into the container at /api
+COPY dist /api/dist
+# Copy the .env file into the container at /api
+COPY .env /api/
+# declare a env variable that can be set from the docker-compose file
+ENV PORT=3000
+# Make the port available to the world outside this container
+EXPOSE $PORT
+# Run the app when the container launches
+CMD ["yarn", "start:prod"]

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "scripts": {
     "start": "nodemon --exec babel-node src/server.js",
+    "start:prod": "node ./dist/server.js",
     "test": "mocha --require babel-core/register src/Tests/**/*.spec.js",
     "pretty": "eslint --fix",
     "precommit": "lint-staged",


### PR DESCRIPTION
* add new start:prod script that runs the server.js in the dist folder with node
* Create new Docker_Prod file that only copies over package.json, .env and /dist, build node_modules without devDependencies  and runs start:prod
* add config and readme to .dockerignore

Issue #21